### PR TITLE
Search improvements and bug fixes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.25
+current_version = 0.0.26
 
 [bumpversion:file:mkdocs_mdpo_plugin/__init__.py]
 

--- a/mkdocs_mdpo_plugin/__init__.py
+++ b/mkdocs_mdpo_plugin/__init__.py
@@ -1,3 +1,3 @@
 """mkdocs-mdpo-plugin package"""
 
-__version__ = '0.0.25'
+__version__ = '0.0.26'

--- a/mkdocs_mdpo_plugin/mkdocs_utils.py
+++ b/mkdocs_mdpo_plugin/mkdocs_utils.py
@@ -1,8 +1,11 @@
 """Mkdocs utilities"""
 
+import functools
 import os
 
 import mkdocs
+
+from mkdocs_mdpo_plugin.utils import removesuffix
 
 
 MKDOCS_MINOR_VERSION_INFO = tuple(
@@ -59,10 +62,24 @@ def set_on_build_error_event(MdpoPlugin):
         atexit.register(_on_build_error)
 
 
+@functools.lru_cache(maxsize=None)
 def get_lunr_languages():
-    response = []
+    languages = []
     for filename in os.listdir(LUNR_LANGUAGES_PATH):
         lang = filename.split('.')[1]
         if len(lang) == 2:
-            response.append(lang)
-    return response
+            languages.append(lang)
+    return languages
+
+
+@functools.lru_cache(maxsize=None)
+def get_material_languages():
+    import material
+
+    languages_dirpath = os.path.join(
+        material.__path__[0], 'partials', 'languages',
+    )
+    languages = []
+    for fname in os.listdir(languages_dirpath):
+        languages.append(removesuffix(fname, '.html'))
+    return languages

--- a/mkdocs_mdpo_plugin/mkdocs_utils.py
+++ b/mkdocs_mdpo_plugin/mkdocs_utils.py
@@ -1,10 +1,15 @@
 """Mkdocs utilities"""
 
-from mkdocs import __version__ as __mkdocs_version__
+import os
+
+import mkdocs
 
 
 MKDOCS_MINOR_VERSION_INFO = tuple(
-    int(n) for n in __mkdocs_version__.split('.')[:2]
+    int(n) for n in mkdocs.__version__.split('.')[:2]
+)
+LUNR_LANGUAGES_PATH = os.path.join(
+    mkdocs.__path__[0], 'contrib', 'search', 'lunr-language',
 )
 
 
@@ -52,3 +57,12 @@ def set_on_build_error_event(MdpoPlugin):
 
         atexit.unregister(_on_build_error)
         atexit.register(_on_build_error)
+
+
+def get_lunr_languages():
+    response = []
+    for filename in os.listdir(LUNR_LANGUAGES_PATH):
+        lang = filename.split('.')[1]
+        if len(lang) == 2:
+            response.append(lang)
+    return response

--- a/mkdocs_mdpo_plugin/mkdocs_utils.py
+++ b/mkdocs_mdpo_plugin/mkdocs_utils.py
@@ -11,9 +11,6 @@ from mkdocs_mdpo_plugin.utils import removesuffix
 MKDOCS_MINOR_VERSION_INFO = tuple(
     int(n) for n in mkdocs.__version__.split('.')[:2]
 )
-LUNR_LANGUAGES_PATH = os.path.join(
-    mkdocs.__path__[0], 'contrib', 'search', 'lunr-language',
-)
 
 
 class MkdocsBuild:
@@ -64,8 +61,12 @@ def set_on_build_error_event(MdpoPlugin):
 
 @functools.lru_cache(maxsize=None)
 def get_lunr_languages():
+    languages_dirpath = os.path.join(
+        mkdocs.__path__[0], 'contrib', 'search', 'lunr-language',
+    )
+
     languages = []
-    for filename in os.listdir(LUNR_LANGUAGES_PATH):
+    for filename in os.listdir(languages_dirpath):
         lang = filename.split('.')[1]
         if len(lang) == 2:
             languages.append(lang)

--- a/mkdocs_mdpo_plugin/plugin.py
+++ b/mkdocs_mdpo_plugin/plugin.py
@@ -35,8 +35,7 @@ from mkdocs_mdpo_plugin.utils import (
 )
 
 
-# use Mkdocs build logger
-logger = logging.getLogger('mkdocs.commands.build')
+logger = logging.getLogger('mkdocs.plugins.mdpo')
 
 
 class MdpoPlugin(mkdocs.plugins.BasePlugin):

--- a/mkdocs_mdpo_plugin/plugin.py
+++ b/mkdocs_mdpo_plugin/plugin.py
@@ -494,7 +494,7 @@ class MdpoPlugin(mkdocs.plugins.BasePlugin):
             config['theme'].language = self.config['default_language']
         elif (
             'search' in config['plugins'] and
-            'lang' in config['plugins']['search']
+            hasattr(config['plugins']['search'], 'lang')
         ):
             config['plugins']['search'].config['lang'] = [
                 self.config['default_language'],

--- a/mkdocs_mdpo_plugin/search_indexes.py
+++ b/mkdocs_mdpo_plugin/search_indexes.py
@@ -38,7 +38,7 @@ def _material_get_worker_js_files(site_dir):
             fpath = os.path.join(javascripts_dir, fname)
             with open(fpath) as f:
                 content = f.read()
-            if '/search/search_index.json' in content:
+            if 'search_index.json' in content:
                 worker_js_filepath = fpath
                 worker_js_content = content
                 continue
@@ -134,8 +134,8 @@ def _material_patch_html_file(fpath, language, worker_files):
     )
 
     new_content = content.replace(
-        f'assets/javascripts/{worker_js_fname}"',
-        f'assets/javascripts/{worker_js_fname_lang}"',
+        f'{worker_js_fname}',
+        f'{worker_js_fname_lang}',
     )
     with open(fpath, 'w') as f:
         f.write(new_content)

--- a/mkdocs_mdpo_plugin/search_indexes.py
+++ b/mkdocs_mdpo_plugin/search_indexes.py
@@ -219,14 +219,6 @@ THEME_PATCH_SEARCH_FILES_FUNCS = {
     'readthedocs': _reathedocs_patch_search_files,
 }
 
-##
-# Update 'search_index.json#config.lang' only for some themes:
-##
-
-THEME_ALTER_SEARCH_INDEX_LANG_CONFIG = [
-    'material',
-]
-
 
 class TranslationsSearchPatcher:
     supported_themes = THEME_WORKER_FILES_FUNCS.keys()
@@ -336,12 +328,6 @@ class TranslationsSearchPatcher:
     def _create_lang_search_index_json(self, language, records):
         search_index = copy.copy(self.search_index_json)
         search_index['docs'] = records
-        if (
-                self.theme_name in THEME_ALTER_SEARCH_INDEX_LANG_CONFIG
-                and 'config' in search_index
-                and 'lang' in search_index['config']
-        ):
-            search_index['config']['lang'] = [language]
 
         new_path = _language_extension_path(
             self.search_index_json_path,

--- a/mkdocs_mdpo_plugin/utils.py
+++ b/mkdocs_mdpo_plugin/utils.py
@@ -1,3 +1,6 @@
+import functools
+
+
 def readable_float(number):
     if str(number).endswith('.0'):
         number = int(number)
@@ -31,3 +34,23 @@ def po_messages_stats(pofile_content):
         total_messages - untranslated_messages,
         total_messages,
     )
+
+
+@functools.lru_cache(maxsize=None)
+def get_package_version(pkg):
+    try:
+        from importlib import metadata
+    except ImportError:
+        try:
+            import importlib_metadata as metadata  # python<=3.7
+        except ImportError:
+            try:
+                import pkg_resources
+            except ImportError:
+                return None
+            else:
+                return pkg_resources.get_distribution(pkg).version
+        else:
+            return metadata.version(pkg)
+    else:
+        return metadata.version(pkg)

--- a/mkdocs_mdpo_plugin/utils.py
+++ b/mkdocs_mdpo_plugin/utils.py
@@ -42,7 +42,7 @@ def get_package_version(pkg):
         from importlib import metadata
     except ImportError:
         try:
-            import importlib_metadata as metadata  # python<=3.7
+            import importlib_metadata as metadata  # python < 3.8
         except ImportError:
             try:
                 import pkg_resources

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ classifiers =
 packages = mkdocs_mdpo_plugin
 install_requires =
     mdpo==0.3.85
+    importlib-metadata;python_version<'3.8'
 python_requires = >=3.6
 include_package_data = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mkdocs_mdpo_plugin
-version = 0.0.25
+version = 0.0.26
 description = Mkdocs plugin for translations using PO files.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,7 @@ def _mkdocs_build(
         mkdocs_logger.setLevel(logging.DEBUG)
         mkdocs_logger.addHandler(logging.FileHandler(mkdocs_logger_f.name))
 
-        plugin_logger = logging.getLogger('mkdocs.commands.build')
+        plugin_logger = logging.getLogger('mkdocs.plugins.mdpo')
         plugin_logger.setLevel(logging.DEBUG)
         plugin_logger.addHandler(logging.FileHandler(plugin_logger_f.name))
 

--- a/tests/test_min_translated_messages.py
+++ b/tests/test_min_translated_messages.py
@@ -4,8 +4,6 @@ import os
 
 import pytest
 
-from mkdocs_mdpo_plugin.plugin import logger
-
 
 TESTS = (
     pytest.param(
@@ -140,13 +138,6 @@ def test_min_translated_messages(
     expected_second_build_log,
     mkdocs_build,
 ):
-    # show duplicated messages in logger
-    #
-    # see Mkdocs build duplicate filter:
-    # https://github.com/mkdocs/mkdocs/blob/
-    # 1da44cea96b850c527d7bdceac920498e4a488ae/mkdocs/commands/build.py#L16
-    logger.filters[0].msgs = set()
-
     def check_translated_files_not_exists(context):
         es_path = os.path.join(context['site_dir'], 'es')
         es_index_path = os.path.join(es_path, 'index.html')


### PR DESCRIPTION
- Add languages to configuration of `search` plugins (Mkdocs and material).
- Fixed incompatibility disabling `cross_language_search` with `mkdocs-minify-plugin` and material theme.
- Don't reuse `mkdocs.commands.build` logger.