### PR TITLE
Allow later versions of mdpo - fix install error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ classifiers =
 [options]
 packages = mkdocs_mdpo_plugin
 install_requires =
-    mdpo==0.3.85
+    mdpo>=0.3.85
     importlib-metadata;python_version<'3.8'
 python_requires = >=3.6
 include_package_data = True


### PR DESCRIPTION
Currently, I face the issue that I cannot install this library. This should be a fix.

```
$ pip install  mkdocs-mdpo-plugin
Collecting mkdocs-mdpo-plugin
  Using cached mkdocs_mdpo_plugin-0.0.27-py3-none-any.whl.metadata (6.5 kB)
Collecting mdpo==0.3.85 (from mkdocs-mdpo-plugin)
  Using cached mdpo-0.3.85-py3-none-any.whl.metadata (5.3 kB)
Collecting polib>=1.1.0 (from mdpo==0.3.85->mkdocs-mdpo-plugin)
  Using cached polib-1.2.0-py2.py3-none-any.whl.metadata (15 kB)
Collecting pymd4c==1.1.2 (from mdpo==0.3.85->mkdocs-mdpo-plugin)
  Using cached pymd4c-1.1.2.tar.gz (51 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [57 lines of output]
      /home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/setuptools/__init__.py:81: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.
      !!
      
              ********************************************************************************
              Requirements should be satisfied by a PEP 517 installer.
              If you are using pip, you can try `pip install --use-pep517`.
              ********************************************************************************
      
      !!
        dist.fetch_build_eggs(dist.setup_requires)
      running egg_info
      creating /tmp/pip-pip-egg-info-0bre8usm/pymd4c.egg-info
      writing /tmp/pip-pip-egg-info-0bre8usm/pymd4c.egg-info/PKG-INFO
      writing dependency_links to /tmp/pip-pip-egg-info-0bre8usm/pymd4c.egg-info/dependency_links.txt
      writing requirements to /tmp/pip-pip-egg-info-0bre8usm/pymd4c.egg-info/requires.txt
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-a_di83ej/pymd4c_21a658f74fe4405d98d01ae8c57b0243/setup.py", line 110, in <module>
          setup(
        File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/setuptools/__init__.py", line 104, in setup
          return distutils.core.setup(**attrs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 185, in setup
          return run_commands(dist)
                 ^^^^^^^^^^^^^^^^^^
        File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
          dist.run_commands()
        File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
          self.run_command(cmd)
        File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/setuptools/dist.py", line 967, in run_command
          super().run_command(command)
        File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
          cmd_obj.run()
        File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 314, in run
          writer(self, ep.name, os.path.join(self.egg_info, ep.name))
        File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 702, in write_toplevel_names
          pkgs = dict.fromkeys([
                               ^
        File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 702, in <listcomp>
          pkgs = dict.fromkeys([
                               ^
        File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/setuptools/dist.py", line 925, in iter_distribution_names
          for ext in self.ext_modules or ():
        File "/tmp/pip-install-a_di83ej/pymd4c_21a658f74fe4405d98d01ae8c57b0243/setup.py", line 61, in __iter__
          self._fetch_pkgconfig_all()
        File "/tmp/pip-install-a_di83ej/pymd4c_21a658f74fe4405d98d01ae8c57b0243/setup.py", line 55, in _fetch_pkgconfig_all
          super().append(self._fetch_pkgconfig(extension))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-install-a_di83ej/pymd4c_21a658f74fe4405d98d01ae8c57b0243/setup.py", line 38, in _fetch_pkgconfig
          for k, v in pkgconfig.parse(libs).items():
                      ^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-install-a_di83ej/pymd4c_21a658f74fe4405d98d01ae8c57b0243/.eggs/pkgconfig-1.5.5-py3.11.egg/pkgconfig/pkgconfig.py", line 248, in parse
          _raise_if_not_exists(package)
        File "/tmp/pip-install-a_di83ej/pymd4c_21a658f74fe4405d98d01ae8c57b0243/.eggs/pkgconfig-1.5.5-py3.11.egg/pkgconfig/pkgconfig.py", line 103, in _raise_if_not_exists
          raise PackageNotFoundError(package)
      pkgconfig.pkgconfig.PackageNotFoundError: md4c not found
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```